### PR TITLE
Linking to External Overlapping Data Sources (WZDz, CWZ, MDS, GBFS, GTFS, Curb Objects, etc)

### DIFF
--- a/curbs/README.md
+++ b/curbs/README.md
@@ -53,7 +53,7 @@ There are four different endpoints that are part of the Curbs API:
     - [Time Span](#time-span)
     - [Rate](#rate) 
   - [Location Reference](#location-reference)
-  - [WXDz Reference](#wzdx-reference)
+  - [WZDx Reference](#wzdx-reference)
   - [Previous Policy](#previous-policy)
 - [Examples](#examples)
 
@@ -511,14 +511,14 @@ A Location Reference is a JSON object with the following fields:
 
 ## WZDx Reference
 
-A WZDx Reference object defines an external connection to a [Work Zone Data Exchange](https://github.com/usdot-jpo-ode/wzdx) data feed for a given curb place. This allows CDS users to reference public WZDx feeds that impact the area, and see full details in the agency data feed.
+A WZDx Reference object describes a specific WZDx road event feature that is relevant to the curb place via an external reference to a [Work Zone Data Exchange](https://github.com/usdot-jpo-ode/wzdx) data feed. This allows CDS users to reference public WZDx feeds that impact the area, and see full details in the agency data feed.
 
 A WZDx Reference is a JSON array with the following fields within objects:
 
 | Name   | Type   | Required/Optional   | Description   |
 | ------ | ------ | ------------------- | ------------- |
 | `wzdx_feed_url` | URL | Required | An identifier for the source of the publicly accessible WZDx feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
-| `wzdx_id` | String | Required | The relevant `id` in the WZDx data feed that impacts the CDS place issued by the data feed provider to identify the WZDx road event, from the [RoadEventFeature](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/RoadEventFeature.md#roadeventfeature-object-geojson-feature). In case multiple road event `wzdx_id`s are needed, then they would be provided in another object with another `wzdx_feed_url`. |
+| `wzdx_road_event_feature_id` | String | Required | The `id` of a WZDx [RoadEventFeature](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/RoadEventFeature.md#roadeventfeature-object-geojson-feature) that impacts the curb zone. In case multiple road event `wzdx_id`s are needed, it would be provided in another object with another `wzdx_feed_url`. |
 
 [Top][toc]
 

--- a/curbs/README.md
+++ b/curbs/README.md
@@ -518,7 +518,7 @@ A WZDx Reference is a JSON array with the following fields within objects:
 | Name   | Type   | Required/Optional   | Description   |
 | ------ | ------ | ------------------- | ------------- |
 | `wzdx_feed_url` | URL | Required | An identifier for the source of the publicly accessible WZDx feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
-| `wzdx_road_event_feature_id` | String | Required | The `id` of a WZDx [RoadEventFeature](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/RoadEventFeature.md#roadeventfeature-object-geojson-feature) that impacts the curb zone. In case multiple road event `wzdx_id`s are needed, it would be provided in another object with another `wzdx_feed_url`. |
+| `wzdx_road_event_feature_id` | String | Required | The `id` of a WZDx [RoadEventFeature](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/RoadEventFeature.md#roadeventfeature-object-geojson-feature) that impacts the use of a curb zone. In case multiple road event `wzdx_id`s are needed, it would be provided in another object with another `wzdx_feed_url`. |
 
 [Top][toc]
 

--- a/curbs/README.md
+++ b/curbs/README.md
@@ -53,6 +53,8 @@ There are four different endpoints that are part of the Curbs API:
     - [Time Span](#time-span)
     - [Rate](#rate) 
   - [Location Reference](#location-reference)
+  - [WXDz Reference](#wzdx-reference)
+  - [Previous Policy](#previous-policy)
 - [Examples](#examples)
 
 # REST Endpoints
@@ -263,6 +265,7 @@ A Curb Zone is represented as a JSON object, whose fields are as follows:
 | `entire_roadway`| Boolean | Optional | If "true", this curb location takes up the entire width of the roadway (which may be impassible for through traffic when the Curb Zone is being used for parking or loading). This is a common condition for alleyways. If `entire_roadway` is `true`, `street_side` MUST NOT be present. |
 | `curb_area_ids`| Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Areas](#curb-area) that this Curb Zone is a part of. If specified, the areas identified MUST be retrievable through the Curb API and its geographical area MUST contain that of the Curb Zone. |
 | `curb_space_ids`| Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Spaces](#curb-space) that this Curb Zone contains. If specified, the spaces identified MUST be retrievable through the Curb API and its geographical area MUST be contained in this Curb Zone. |
+| `wzdx_references` | Array of [WZDx Reference](#wzdx-reference) objects | Optional | One or more references to external [WZDX data feeds](https://github.com/usdot-jpo-ode/wzdx) impacting this Curb Zone. |
 
 [Top][toc]
 
@@ -296,6 +299,7 @@ A Curb Area is represented as a JSON object, whose fields are as follows:
 | `published_date` | [Timestamp][ts] | Required | The date/time that this curb area was first published in this data feed. |
 | `last_updated_date` | [Timestamp][ts] | Required | The date/time that the properties of ths curb area were last updated. This helps consumers know that some fields may have changed. |
 | `curb_zone_ids` | Array of [UUIDs][uuid] | Required | The IDs of all the Curb Zones included within this Curb Area at the requested time.	|
+| `wzdx_references` | Array of [WZDx Reference](#wzdx-reference) objects | Optional | One or more references to external [WZDX data feeds](https://github.com/usdot-jpo-ode/wzdx) impacting this Curb Zone. |
 
 [Top][toc]
 
@@ -322,6 +326,7 @@ A Curb Space is represented as a JSON object whose fields are as follows:
 | `width` | Integer | Optional | Width in centimeters of this Space. | If comparing the length of a vehicle to that of a space, note that vehicles may have to account for a buffer for doors, mirrors, bumpers, ramps, etc. |
 | `available` | Boolean | Optional | Whether this space is available for vehicles to park in at the specified time  (‘True’ means the Space is available). |
 | `availability_time` | [Timestamp][ts] | Optional | If availability information is present, the most recent time that availability was computed for this space. |
+| `wzdx_references` | Array of [WZDx Reference](#wzdx-reference) objects | Optional | One or more references to external [WZDX data feeds](https://github.com/usdot-jpo-ode/wzdx) impacting this Curb Zone. |
 
 [Top][toc]
 
@@ -503,7 +508,20 @@ A Location Reference is a JSON object with the following fields:
 | `side` | String | Optional | If the referenced linear feature is a roadway, the side of the roadway on which the Curb Zone may be found, when heading from the start to the end of the feature in its native orientation. Values are `left` and `right`. MUST be absent for features where `entire_roadway` is true. |
 
 [Top][toc]
-  
+
+## WZDx Reference
+
+A WZDx Reference object defines an external connection to a [Work Zone Data Exchange](https://github.com/usdot-jpo-ode/wzdx) data feed for a given curb place. This allows CDS users to reference public WZDx feeds that impact the area, and see full details in the agency data feed.
+
+A WZDx Reference is a JSON array with the following fields within objects:
+
+| Name   | Type   | Required/Optional   | Description   |
+| ------ | ------ | ------------------- | ------------- |
+| `wzdx_feed_url` | URL | Required | An identifier for the source of the publicly accessible WZDx feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
+| `wzdx_id` | String | Required | The relevant `id` in the WZDx data feed that impacts the CDS place issued by the data feed provider to identify the WZDx road event, from the [RoadEventFeature](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/RoadEventFeature.md#roadeventfeature-object-geojson-feature). In case multiple road event `wzdx_id`s are needed, then they would be provided in another object with another `wzdx_feed_url`. |
+
+[Top][toc]
+
 ## Previous Policy
 
 An array of information about what previous policies applied to a [curb zone](#curb-zone) and when. This allows cities to historically track what policies applied to a curb zone.
@@ -517,7 +535,7 @@ A Previous Policy is a JSON object with the following fields:
 | `end_date` | [Timestamp][ts] | Required | The date/time that this policy ended being active for this curb location (_exclusive_, see [Range Boundaries](/general-information.md#range-boundaries)). |
 
 [Top][toc]
- 
+
 # Examples
 
 See a series of [CDS Curbs endpoint examples](examples.md) to use as templates. 

--- a/curbs/README.md
+++ b/curbs/README.md
@@ -650,7 +650,7 @@ A WZDx Reference is a JSON array with the following fields within objects:
 | Name   | Type   | Required/Optional   | Description   |
 | ------ | ------ | ------------------- | ------------- |
 | `wzdx_feed_url` | URL | Required | An identifier for the source of the publicly accessible WZDx feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
-| `wzdx_road_event_feature_id` | String | Required | The `id` of a WZDx [RoadEventFeature](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/RoadEventFeature.md#roadeventfeature-object-geojson-feature) that impacts the use of a curb zone. In case multiple road event `wzdx_id`s are needed, it would be provided in another object with another `wzdx_feed_url`. |
+| `wzdx_road_event_feature_ids` | Array | Required | An array of **ids** of a WZDx [RoadEventFeature](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/RoadEventFeature.md#roadeventfeature-object-geojson-feature) that impacts the use of a curb zone. The **ids** details are be provided in the `wzdx_feed_url`. |
 
 [Top][toc]
 

--- a/curbs/README.md
+++ b/curbs/README.md
@@ -311,7 +311,7 @@ A Curb Zone is represented as a JSON object, whose fields are as follows:
 | `curb_area_ids`| Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Areas](#curb-area) that this Curb Zone is a part of. If specified, the areas identified MUST be retrievable through the Curb API and its geographical area MUST contain that of the Curb Zone. |
 | `curb_space_ids`| Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Spaces](#curb-space) that this Curb Zone contains. If specified, the spaces identified MUST be retrievable through the Curb API and its geographical area MUST be contained in this Curb Zone. |
 | `curb_object_ids` | Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Objects](#curb-object) that this Curb Zone is related to, in particular what Objects are in the Zone's areas of influence. For example, a pay station being used for multiple paid parking zones, a locker for a commercial loading zone, or a camera monitoring several zones. If specified, the objects identified MUST be retrievable through the Curb API. Curb Objects can be related to a Curb Space or a Curb Zone. |
-| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
+| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Zone. References external data that is relevant to this Zone now. If the external reference is temporary, it should be added, then removed when no longer relevant.  This field can be changed without requiring a new `curb_zone_id`, as it does not impact the Zone's geographic definition.  |
 
 [Top][toc]
 
@@ -345,7 +345,7 @@ A Curb Area is represented as a JSON object, whose fields are as follows:
 | `published_date` | [Timestamp][ts] | Required | The date/time that this curb area was first published in this data feed. |
 | `last_updated_date` | [Timestamp][ts] | Required | The date/time that the properties of ths curb area were last updated. This helps consumers know that some fields may have changed. |
 | `curb_zone_ids` | Array of [UUIDs][uuid] | Required | The IDs of all the Curb Zones included within this Curb Area at the requested time.	|
-| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
+| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Area. References external data that is relevant to this Area now. If the external reference is temporary, it should be added, then removed when no longer relevant. |
 
 [Top][toc]
 
@@ -373,7 +373,7 @@ A Curb Space is represented as a JSON object whose fields are as follows:
 | `width` | Integer | Optional | Width in centimeters of this Space. | If comparing the length of a vehicle to that of a space, note that vehicles may have to account for a buffer for doors, mirrors, bumpers, ramps, etc. |
 | `available` | Boolean | Optional | Whether this space is available for vehicles to park in at the specified time  (‘True’ means the Space is available). |
 | `availability_time` | [Timestamp][ts] | Optional | If availability information is present, the most recent time that availability was computed for this space. |
-| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
+| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Space. References external data that is relevant to this Space now. If the external reference is temporary, it should be added, then removed when no longer relevant. |
 
 [Top][toc]
 
@@ -409,7 +409,7 @@ A Curb Object is represented as a JSON object whose fields are as follows:
 | `max_height` | Integer | Optional | Maximum, bounding box height of the object from the sidewalk/street surface, in centimeters. |
 | `published_date` | [Timestamp][ts] | Required | The date/time that this curb object was first published in this data feed. |
 | `last_updated_date` | [Timestamp][ts] | Required | The date/time that the properties of ths curb object were last updated. This helps consumers know that some fields may have changed. |
-| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
+| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Object. References external data that is relevant to this Object now. If the external reference is temporary, it should be added, then removed when no longer relevant. |
 
 [Top][toc]
 

--- a/curbs/README.md
+++ b/curbs/README.md
@@ -60,7 +60,7 @@ There are four different endpoints that are part of the Curbs API:
     - [Time Span](#time-span)
     - [Rate](#rate) 
   - [Location Reference](#location-reference)
-  - [WZDx Reference](#wzdx-reference)
+  - [External Reference](#external-reference)
   - [Previous Policy](#previous-policy)
 - [Examples](#examples)
 - [Schema](#schema)
@@ -312,8 +312,7 @@ A Curb Zone is represented as a JSON object, whose fields are as follows:
 | `curb_area_ids`| Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Areas](#curb-area) that this Curb Zone is a part of. If specified, the areas identified MUST be retrievable through the Curb API and its geographical area MUST contain that of the Curb Zone. |
 | `curb_space_ids`| Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Spaces](#curb-space) that this Curb Zone contains. If specified, the spaces identified MUST be retrievable through the Curb API and its geographical area MUST be contained in this Curb Zone. |
 | `curb_object_ids` | Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Objects](#curb-object) that this Curb Zone is related to, in particular what Objects are in the Zone's areas of influence. For example, a pay station being used for multiple paid parking zones, a locker for a commercial loading zone, or a camera monitoring several zones. If specified, the objects identified MUST be retrievable through the Curb API. Curb Objects can be related to a Curb Space or a Curb Zone. |
-| `wzdx_references` | Array of [WZDx Reference](#wzdx-reference) objects | Optional | One or more references to external [WZDX data feeds](https://github.com/usdot-jpo-ode/wzdx) impacting this Curb Zone. |
-
+| `external_references` | Array of [External Reference](#external-reference) objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
 
 [Top][toc]
 
@@ -347,7 +346,7 @@ A Curb Area is represented as a JSON object, whose fields are as follows:
 | `published_date` | [Timestamp][ts] | Required | The date/time that this curb area was first published in this data feed. |
 | `last_updated_date` | [Timestamp][ts] | Required | The date/time that the properties of ths curb area were last updated. This helps consumers know that some fields may have changed. |
 | `curb_zone_ids` | Array of [UUIDs][uuid] | Required | The IDs of all the Curb Zones included within this Curb Area at the requested time.	|
-| `wzdx_references` | Array of [WZDx Reference](#wzdx-reference) objects | Optional | One or more references to external [WZDX data feeds](https://github.com/usdot-jpo-ode/wzdx) impacting this Curb Zone. |
+| `external_references` | Array of [External Reference](#external-reference) objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
 
 [Top][toc]
 
@@ -375,7 +374,7 @@ A Curb Space is represented as a JSON object whose fields are as follows:
 | `width` | Integer | Optional | Width in centimeters of this Space. | If comparing the length of a vehicle to that of a space, note that vehicles may have to account for a buffer for doors, mirrors, bumpers, ramps, etc. |
 | `available` | Boolean | Optional | Whether this space is available for vehicles to park in at the specified time  (‘True’ means the Space is available). |
 | `availability_time` | [Timestamp][ts] | Optional | If availability information is present, the most recent time that availability was computed for this space. |
-| `wzdx_references` | Array of [WZDx Reference](#wzdx-reference) objects | Optional | One or more references to external [WZDX data feeds](https://github.com/usdot-jpo-ode/wzdx) impacting this Curb Zone. |
+| `external_references` | Array of [External Reference](#external-reference) objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
 
 [Top][toc]
 
@@ -641,16 +640,17 @@ A Location Reference is a JSON object with the following fields:
 
 [Top][toc]
 
-## WZDx Reference
+## External Reference
 
-A WZDx Reference object describes a specific WZDx road event feature that is relevant to the curb place via an external reference to a [Work Zone Data Exchange](https://github.com/usdot-jpo-ode/wzdx) data feed. This allows CDS users to reference public WZDx feeds that impact the area, and see full details in the agency data feed.
+An External Reference object describes a specific feature from a data feed or API that is relevant to the curb place via an external reference. This allows CDS users to reference other data feeds that impact the area, and see full details in the agency's data feed. Data feeds can be any existing standard (MDS, WzDX, CWZ, GTFS, GBFS, etc) or a custom feed.
 
-A WZDx Reference is a JSON array with the following fields within objects:
+An `external_reference` is a JSON array with the following fields within objects:
 
 | Name   | Type   | Required/Optional   | Description   |
 | ------ | ------ | ------------------- | ------------- |
-| `wzdx_feed_url` | URL | Required | An identifier for the source of the publicly accessible WZDx feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
-| `wzdx_road_event_feature_ids` | Array | Required | An array of **ids** of a WZDx [RoadEventFeature](https://github.com/usdot-jpo-ode/wzdx/blob/main/spec-content/objects/RoadEventFeature.md#roadeventfeature-object-geojson-feature) that impacts the use of a curb zone. The **ids** details are be provided in the `wzdx_feed_url`. |
+| `data_feed_url` | URL | Required | An identifier for the source of the publicly or privately accessible data feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
+| `field_name` | String | Required | The name of the data field that is referenced by `feature_ids`. E.g. "trip_id". |
+| `feature_ids` | Array | Required | An array of one or more **ids** strings of a data feed that impacts the use of or relationship to a curb zone. The **ids** details are be provided in the referenced `data_feed_url`. |
 
 [Top][toc]
 

--- a/curbs/README.md
+++ b/curbs/README.md
@@ -311,7 +311,7 @@ A Curb Zone is represented as a JSON object, whose fields are as follows:
 | `curb_area_ids`| Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Areas](#curb-area) that this Curb Zone is a part of. If specified, the areas identified MUST be retrievable through the Curb API and its geographical area MUST contain that of the Curb Zone. |
 | `curb_space_ids`| Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Spaces](#curb-space) that this Curb Zone contains. If specified, the spaces identified MUST be retrievable through the Curb API and its geographical area MUST be contained in this Curb Zone. |
 | `curb_object_ids` | Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Objects](#curb-object) that this Curb Zone is related to, in particular what Objects are in the Zone's areas of influence. For example, a pay station being used for multiple paid parking zones, a locker for a commercial loading zone, or a camera monitoring several zones. If specified, the objects identified MUST be retrievable through the Curb API. Curb Objects can be related to a Curb Space or a Curb Zone. |
-| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Zone. References external data that is relevant to this Zone now. If the external reference is temporary, it should be added, then removed when no longer relevant.  This field can be changed without requiring a new `curb_zone_id`, as it does not impact the Zone's geographic definition.  |
+| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Zone. References external data that is relevant to this Zone now. If the external reference is temporary, it should be added, then removed when no longer relevant.  This field can be changed without requiring a new `curb_zone_id`, as it does not impact the Zone's geographic definition. |
 
 [Top][toc]
 
@@ -473,6 +473,8 @@ A Policy is represented as a JSON object whose fields are as follows:
 | `rules` | Array of [Rules](#rule) | Required | The rule(s) that this policy applies. If a Policy specifies multiple rules, each rule MUST specify disjoint lists of user classes. |
 | `time_spans` | Array of [Time Spans](#time-span) | Optional | If specified, this regulation only applies at the times defined within. |
 | `data_source_operator_id` | Array of [UUIDs][uuid] | Optional | An array of Data Source Operator IDs that this policy only applies to. IDs come from [data_source_operators.csv](/data_source_operators.csv) file here in the CDS repo. Read our [How to Get a Data Source Operator ID](https://github.com/openmobilityfoundation/curb-data-specification/wiki/Adding-a-CDS-Data-Source-Operator-ID) guide. |
+| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Policy. References external data that is relevant to this Policy at the time of its creation. More specific and timely external references can be made in related Zones, Spaces, and Areas. |
+
 
 [Top][toc]
 

--- a/curbs/README.md
+++ b/curbs/README.md
@@ -60,7 +60,6 @@ There are four different endpoints that are part of the Curbs API:
     - [Time Span](#time-span)
     - [Rate](#rate) 
   - [Location Reference](#location-reference)
-  - [External Reference](#external-reference)
   - [Previous Policy](#previous-policy)
 - [Examples](#examples)
 - [Schema](#schema)
@@ -312,7 +311,7 @@ A Curb Zone is represented as a JSON object, whose fields are as follows:
 | `curb_area_ids`| Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Areas](#curb-area) that this Curb Zone is a part of. If specified, the areas identified MUST be retrievable through the Curb API and its geographical area MUST contain that of the Curb Zone. |
 | `curb_space_ids`| Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Spaces](#curb-space) that this Curb Zone contains. If specified, the spaces identified MUST be retrievable through the Curb API and its geographical area MUST be contained in this Curb Zone. |
 | `curb_object_ids` | Array of [UUID][uuid] | Optional | The ID(s) of the [Curb Objects](#curb-object) that this Curb Zone is related to, in particular what Objects are in the Zone's areas of influence. For example, a pay station being used for multiple paid parking zones, a locker for a commercial loading zone, or a camera monitoring several zones. If specified, the objects identified MUST be retrievable through the Curb API. Curb Objects can be related to a Curb Space or a Curb Zone. |
-| `external_references` | Array of [External Reference](#external-reference) objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
+| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
 
 [Top][toc]
 
@@ -346,7 +345,7 @@ A Curb Area is represented as a JSON object, whose fields are as follows:
 | `published_date` | [Timestamp][ts] | Required | The date/time that this curb area was first published in this data feed. |
 | `last_updated_date` | [Timestamp][ts] | Required | The date/time that the properties of ths curb area were last updated. This helps consumers know that some fields may have changed. |
 | `curb_zone_ids` | Array of [UUIDs][uuid] | Required | The IDs of all the Curb Zones included within this Curb Area at the requested time.	|
-| `external_references` | Array of [External Reference](#external-reference) objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
+| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
 
 [Top][toc]
 
@@ -374,7 +373,7 @@ A Curb Space is represented as a JSON object whose fields are as follows:
 | `width` | Integer | Optional | Width in centimeters of this Space. | If comparing the length of a vehicle to that of a space, note that vehicles may have to account for a buffer for doors, mirrors, bumpers, ramps, etc. |
 | `available` | Boolean | Optional | Whether this space is available for vehicles to park in at the specified time  (‘True’ means the Space is available). |
 | `availability_time` | [Timestamp][ts] | Optional | If availability information is present, the most recent time that availability was computed for this space. |
-| `external_references` | Array of [External Reference](#external-reference) objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
+| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
 
 [Top][toc]
 
@@ -410,8 +409,7 @@ A Curb Object is represented as a JSON object whose fields are as follows:
 | `max_height` | Integer | Optional | Maximum, bounding box height of the object from the sidewalk/street surface, in centimeters. |
 | `published_date` | [Timestamp][ts] | Required | The date/time that this curb object was first published in this data feed. |
 | `last_updated_date` | [Timestamp][ts] | Required | The date/time that the properties of ths curb object were last updated. This helps consumers know that some fields may have changed. |
-| `external_object_id` | String | Optional | A unique identifier for this object from an external source, like `external_object_url`. |
-| `external_object_url` | URL | Optional | A URL link to a data feed that contains the `external_object_id`. |
+| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Zone. |
 
 [Top][toc]
 
@@ -640,20 +638,6 @@ A Location Reference is a JSON object with the following fields:
 
 [Top][toc]
 
-## External Reference
-
-An External Reference object describes a specific feature from a data feed or API that is relevant to the curb place via an external reference. This allows CDS users to reference other data feeds that impact the area, and see full details in the agency's data feed. Data feeds can be any existing standard (MDS, WzDX, CWZ, GTFS, GBFS, etc) or a custom feed.
-
-An `external_reference` is a JSON array with the following fields within objects:
-
-| Name   | Type   | Required/Optional   | Description   |
-| ------ | ------ | ------------------- | ------------- |
-| `data_feed_url` | URL | Required | An identifier for the source of the publicly or privately accessible data feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
-| `field_name` | String | Required | The name of the data field that is referenced by `feature_ids`. E.g. "trip_id". |
-| `feature_ids` | Array | Required | An array of one or more **ids** strings of a data feed that impacts the use of or relationship to a curb zone. The **ids** details are be provided in the referenced `data_feed_url`. |
-
-[Top][toc]
-
 ## Previous Policy
 
 An array of information about what previous policies applied to a [curb zone](#curb-zone) and when. This allows cities to historically track what policies applied to a curb zone.
@@ -680,6 +664,7 @@ For details on the CDS schema in OpenAPI format and on Stoplight, please referen
 
 [Top][toc]
 
+[external-reference]: ../data-types.md#external-reference
 [toc]: #table-of-contents
 [uuid]: /general-information.md#uuid
 [ts]: /general-information.md#timestamp

--- a/data-types.md
+++ b/data-types.md
@@ -15,8 +15,9 @@ An `external_reference` is a JSON array with the following fields within objects
 | Name   | Type   | Required/Optional   | Description   |
 | ------ | ------ | ------------------- | ------------- |
 | `data_feed_url` | URL | Required | An identifier for the source of the publicly or privately accessible data feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
-| `field_name` | String | Required | The name of the data field that is referenced by `feature_ids`. E.g. "trip_id". |
-| `feature_ids` | Array | Required | An array of one or more **ids** strings of a data feed that impacts the use of or relationship to a curb zone. The **ids** details are be provided in the referenced `data_feed_url`. |
+| `name` | String | Optional | Name of the data feed for reference. E.g. "WZDz", "CWZ", "MDS", "GBFS", "GTFS", "CDS". |
+| `field_name` | String | Optional | The name of the data field that is referenced by `feature_ids`. E.g. "trip_id". |
+| `feature_ids` | Array | Optional | An array of one or more **ids** strings of a data feed that impacts the use of or relationship to a curb zone. The **ids** details are be provided in the referenced `data_feed_url`. |
 
 [Top][toc]
 

--- a/data-types.md
+++ b/data-types.md
@@ -17,7 +17,7 @@ An `external_reference` is a JSON *array* with the following fields within objec
 | `data_feed_url` | URL | Required | An identifier for the source of the publicly or privately accessible data feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
 | `name` | String | Optional | Name of the data feed for reference. E.g. "WZDx", "CWZ", "MDS", "GBFS", "GTFS", "CDS". |
 | `identifier_name` | String | Optional | The name of the data field or object that is referenced by unique `ids`. E.g. "id", "trip_id", "vehicle_id", "RoadEventFeature", etc. |
-| `ids` | String Array | Optional | An array of one or more **ids** from the data feed that impacts the use of or relationship to part of CDS, e.g. a curb zone, curb space, curb area, curb event, etc. The **ids** and their details are be found in the referenced `data_feed_url`. |
+| `ids` | Array of Strings | Optional | An array of one or more **ids** from the data feed that impacts the use of or relationship to part of CDS, e.g. a curb zone, curb space, curb area, curb event, etc. The **ids** and their details are be found in the referenced `data_feed_url`. |
 
 [Top][toc]
 

--- a/data-types.md
+++ b/data-types.md
@@ -8,16 +8,16 @@ This CDS data types page catalogs the data objects (fields, types, requirements,
 
 ## External Reference
 
-An External Reference object describes a specific feature from a data feed or API that is relevant to the curb place via an external reference. This allows CDS users to reference other data feeds that impact the area, and see full details in the agency's data feed. Data feeds can be any existing standard (MDS, WzDX, CWZ, GTFS, GBFS, etc) or a custom feed.
+An External Reference object describes a specific feature from a data feed or API that is relevant to the curb place via an external reference. This allows CDS users to reference other data feeds that impact the area, and see full details in the agency's data feed. Data feeds can be any existing standard (MDS, WZDx, CWZ, GTFS, GBFS, CDS, etc) or a custom feed.
 
-An `external_reference` is a JSON array with the following fields within objects:
+An `external_reference` is a JSON *array* with the following fields within objects:
 
 | Name   | Type   | Required/Optional   | Description   |
 | ------ | ------ | ------------------- | ------------- |
 | `data_feed_url` | URL | Required | An identifier for the source of the publicly or privately accessible data feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
-| `name` | String | Optional | Name of the data feed for reference. E.g. "WZDz", "CWZ", "MDS", "GBFS", "GTFS", "CDS". |
-| `field_name` | String | Optional | The name of the data field that is referenced by `feature_ids`. E.g. "trip_id". |
-| `feature_ids` | Array | Optional | An array of one or more **ids** strings of a data feed that impacts the use of or relationship to part of CDS, e.g. a curb zone or space. The **ids** details are be provided in the referenced `data_feed_url`. |
+| `name` | String | Optional | Name of the data feed for reference. E.g. "WZDx", "CWZ", "MDS", "GBFS", "GTFS", "CDS". |
+| `identifier_name` | String | Optional | The name of the data field or object that is referenced by unique `ids`. E.g. "id", "trip_id", "vehicle_id", "RoadEventFeature", etc. |
+| `ids` | String Array | Optional | An array of one or more **ids** from the data feed that impacts the use of or relationship to part of CDS, e.g. a curb zone, curb space, curb area, curb event, etc. The **ids** and their details are be found in the referenced `data_feed_url`. |
 
 [Top][toc]
 

--- a/data-types.md
+++ b/data-types.md
@@ -8,16 +8,16 @@ This CDS data types page catalogs the data objects (fields, types, requirements,
 
 ## External Reference
 
-An External Reference object describes a specific feature from a data feed or API that is relevant to the curb place via an external reference. This allows CDS users to reference other data feeds that impact the area, and see full details in the agency's data feed. Data feeds can be any existing standard (MDS, WZDx, CWZ, GTFS, GBFS, CDS, etc) or a custom feed.
+An External Reference object describes a specific feature from a data feed or API that is relevant to the curb place via an external reference. This allows CDS users to reference other data feeds, documents, websites, or URLs that impact or provide information, and see more details in an external URL. Data feeds can be any existing standard (MDS, WZDx, CWZ, GTFS, GBFS, CDS, etc), custom feed, document, web page, etc.
 
 An `external_reference` is a JSON *array* with the following fields within objects:
 
 | Name   | Type   | Required/Optional   | Description   |
 | ------ | ------ | ------------------- | ------------- |
-| `data_feed_url` | URL | Required | An identifier for the source of the publicly or privately accessible data feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
+| `data_feed_url` | URL | Required | A web-accessible identifier for the source of the publicly or privately accessible data feed, document, website, or URL. This MUST be a full HTTPS URL pointing to a location which contains more information impacting or explaining the location or policy. |
 | `name` | String | Optional | Name of the data feed for reference. E.g. "WZDx", "CWZ", "MDS", "GBFS", "GTFS", "CDS". |
 | `public` | Boolean | Optional | Is this data feed able to be viewed with out any sort of authentication? If `true`, the `data_feed_url` is public. If `false`, the `data_feed_url` requires some sort of authentication, authorization, or API key to access. This is an informational field to set access expectations for the feed user, and does not provide any credentials directly unless explicitly contained in the `data_feed_url` URL string. |
-| `identifier_name` | String | Optional | The name of the data field or object that is referenced by unique `ids`. E.g. "id", "trip_id", "vehicle_id", "RoadEventFeature", etc. |
+| `identifier_name` | String | Optional | The name of the data field or object that is referenced by the unique `ids`. E.g. "id", "trip_id", "vehicle_id", "RoadEventFeature", etc, if relevant and available in the URL. |
 | `ids` | Array of Strings | Optional | An array of one or more **ids** from the data feed that impacts the use of or relationship to part of CDS, e.g. a curb zone, curb space, curb area, curb event, etc. The **ids** and their details are be found in the referenced `data_feed_url`. |
 
 [Top][toc]

--- a/data-types.md
+++ b/data-types.md
@@ -17,7 +17,7 @@ An `external_reference` is a JSON array with the following fields within objects
 | `data_feed_url` | URL | Required | An identifier for the source of the publicly or privately accessible data feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
 | `name` | String | Optional | Name of the data feed for reference. E.g. "WZDz", "CWZ", "MDS", "GBFS", "GTFS", "CDS". |
 | `field_name` | String | Optional | The name of the data field that is referenced by `feature_ids`. E.g. "trip_id". |
-| `feature_ids` | Array | Optional | An array of one or more **ids** strings of a data feed that impacts the use of or relationship to a curb zone. The **ids** details are be provided in the referenced `data_feed_url`. |
+| `feature_ids` | Array | Optional | An array of one or more **ids** strings of a data feed that impacts the use of or relationship to part of CDS, e.g. a curb zone or space. The **ids** details are be provided in the referenced `data_feed_url`. |
 
 [Top][toc]
 

--- a/data-types.md
+++ b/data-types.md
@@ -16,6 +16,7 @@ An `external_reference` is a JSON *array* with the following fields within objec
 | ------ | ------ | ------------------- | ------------- |
 | `data_feed_url` | URL | Required | An identifier for the source of the publicly or privately accessible data feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
 | `name` | String | Optional | Name of the data feed for reference. E.g. "WZDx", "CWZ", "MDS", "GBFS", "GTFS", "CDS". |
+| `public` | Boolean | Optional | Is this data feed able to be viewed with out any sort of authentication? If `true`, the `data_feed_url` is public. If `false`, the `data_feed_url` requires some sort of authentication, authorization, or API key to access. This is an informational field to set access expectations for the feed user, and does not provide any credentials directly unless explicitly contained in the `data_feed_url` URL string. |
 | `identifier_name` | String | Optional | The name of the data field or object that is referenced by unique `ids`. E.g. "id", "trip_id", "vehicle_id", "RoadEventFeature", etc. |
 | `ids` | Array of Strings | Optional | An array of one or more **ids** from the data feed that impacts the use of or relationship to part of CDS, e.g. a curb zone, curb space, curb area, curb event, etc. The **ids** and their details are be found in the referenced `data_feed_url`. |
 

--- a/data-types.md
+++ b/data-types.md
@@ -1,0 +1,23 @@
+# Curb Data Specification: **Data Types**
+
+This CDS data types page catalogs the data objects (fields, types, requirements, descriptions) used across CDS APIs and endpoints.
+
+## Table of Contents
+
+- [External Reference](#external-reference)
+
+## External Reference
+
+An External Reference object describes a specific feature from a data feed or API that is relevant to the curb place via an external reference. This allows CDS users to reference other data feeds that impact the area, and see full details in the agency's data feed. Data feeds can be any existing standard (MDS, WzDX, CWZ, GTFS, GBFS, etc) or a custom feed.
+
+An `external_reference` is a JSON array with the following fields within objects:
+
+| Name   | Type   | Required/Optional   | Description   |
+| ------ | ------ | ------------------- | ------------- |
+| `data_feed_url` | URL | Required | An identifier for the source of the publicly or privately accessible data feed. This MUST be a full HTTPS URL pointing to the data feed which contains more information about the underlying work zone impacting the CDS place. |
+| `field_name` | String | Required | The name of the data field that is referenced by `feature_ids`. E.g. "trip_id". |
+| `feature_ids` | Array | Required | An array of one or more **ids** strings of a data feed that impacts the use of or relationship to a curb zone. The **ids** details are be provided in the referenced `data_feed_url`. |
+
+[Top][toc]
+
+[toc]: #table-of-contents

--- a/events/README.md
+++ b/events/README.md
@@ -128,6 +128,7 @@ A Curb Event is represented as a JSON object, whose fields are as follows:
 | `vehicle_blocked_lane_types` | Array of [Lane Type](#lane-type) | Conditionally Required | Type(s) of lane blocked by the vehicle performing the event. If no lanes are blocked by the vehicle performing the event, the array should be empty.  Required for sources capable of determining it for the following event_types: _park_start_ |
 | `curb_occupants` | Array of [Curb Occupant](#curb-occupants) | Conditionally Required | Current occupants of the Curb Zone. If the sensor is capable of identifying the linear location of the vehicle, then elements are sorted in ascending order according to the start property of the linear reference. Otherwise, elements appear in no particular order. Required for sources capable of determining it for the following event_types: _park_start, park_end, scheduled_report_ |
 | `actual_cost` | Integer | Optional | If available from the source, the actual cost, in the currency defined in currency, paid by the curb user for this event. The currency type is sent in with the [REST Endpoints](#rest-endpoints) JSON object. All costs should be given as integers in the currency's smallest unit. As an example, to represent $1 USD, specify an amount of 100 (for 100 cents). |
+| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Event. |
 
 [Top][toc]
 

--- a/events/README.md
+++ b/events/README.md
@@ -128,7 +128,7 @@ A Curb Event is represented as a JSON object, whose fields are as follows:
 | `vehicle_blocked_lane_types` | Array of [Lane Type](#lane-type) | Conditionally Required | Type(s) of lane blocked by the vehicle performing the event. If no lanes are blocked by the vehicle performing the event, the array should be empty.  Required for sources capable of determining it for the following event_types: _park_start_ |
 | `curb_occupants` | Array of [Curb Occupant](#curb-occupants) | Conditionally Required | Current occupants of the Curb Zone. If the sensor is capable of identifying the linear location of the vehicle, then elements are sorted in ascending order according to the start property of the linear reference. Otherwise, elements appear in no particular order. Required for sources capable of determining it for the following event_types: _park_start, park_end, scheduled_report_ |
 | `actual_cost` | Integer | Optional | If available from the source, the actual cost, in the currency defined in currency, paid by the curb user for this event. The currency type is sent in with the [REST Endpoints](#rest-endpoints) JSON object. All costs should be given as integers in the currency's smallest unit. As an example, to represent $1 USD, specify an amount of 100 (for 100 cents). |
-| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Event. |
+| `external_references` | Array of [External Reference][external-reference] objects | Optional | One or more references to external data feeds impacting this Curb Event. The external reference is relevant to the moment in time the event happens. |
 
 [Top][toc]
 


### PR DESCRIPTION
## Explain pull request

Adding a reference to WZDx data feeds in CDS's Curbs API per issue #74 

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which API(s) will this pull request impact?

* `Curbs`
* `Events`

