### PR TITLE
Add field - maximum_fee

### DIFF
--- a/curbs/README.md
+++ b/curbs/README.md
@@ -486,6 +486,7 @@ A Rate defines the amount a user of the curb needs to pay when a given rule appl
 | `increment_amount` | Integer | Optional | If specified, the rate for this space is rounded up to the nearest increment of this amount, specified in the same currency units as `rate`. |
 | `start_duration` | Integer | Optional | The number of `rate_unit`s the vehicle must have already been present in the Curb Zone before this rate starts applying (_inclusive_, see [Range Boundaries](/general-information.md#range-boundaries)). If not specified, this rate starts when the vehicle arrives. |
 | `end_duration` | Integer | Optional | The number of `rate_unit`s after which the rate stops applying (_exclusive_, see [Range Boundaries](/general-information.md#range-boundaries)). If not specified, this rate ends when the vehicle departs. |
+| `maximum_fee` | Integer | Optional | The maximum amount a user of a curb can pay for a particular parking event. |
 
 [Top][toc]
 

--- a/curbs/README.md
+++ b/curbs/README.md
@@ -486,7 +486,7 @@ A Rate defines the amount a user of the curb needs to pay when a given rule appl
 | `increment_amount` | Integer | Optional | If specified, the rate for this space is rounded up to the nearest increment of this amount, specified in the same currency units as `rate`. |
 | `start_duration` | Integer | Optional | The number of `rate_unit`s the vehicle must have already been present in the Curb Zone before this rate starts applying (_inclusive_, see [Range Boundaries](/general-information.md#range-boundaries)). If not specified, this rate starts when the vehicle arrives. |
 | `end_duration` | Integer | Optional | The number of `rate_unit`s after which the rate stops applying (_exclusive_, see [Range Boundaries](/general-information.md#range-boundaries)). If not specified, this rate ends when the vehicle departs. |
-| `maximum_fee` | Integer | Optional | The maximum amount a user of a curb can pay for a particular parking event. |
+| `maximum_fee` | Integer | Optional | The maximum amount in cents a user of a curb can pay for a particular parking event. |
 
 [Top][toc]
 


### PR DESCRIPTION
---
name: Mitch Vars

title: Add maximum _fee field to Rate

---

# CDS Pull Request


## Explain pull request

Current spec does not support rates that have a maximum fee amount. This PR adds a new field to Rate called `maximum_fee` that represents the maximum amount a user of a curb can pay for a particular parking event. Discussion of this topic can be found in #116.


## Is this a breaking change


* No, not breaking


## Impacted Spec

* `Curbs`



