### PR TITLE
Add links to OpenAPI schema and Stoplight

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Curb Data Specification APIs](#curb-data-specification-apis)
   - [Structure](#structure)
   - [Modularity](#modularity)
+  - [CDS OpenAPI Schema](#cds-openapi-schema)
   - [MDS Overlap](#mds-overlap)
 - [Work in Progress](#work-in-progress)
 - [Get Involved](#get-involved)
@@ -15,7 +16,6 @@
 - [Organizations Using CDS](#organizations-using-cds) 
 - [Data Privacy](#data-privacy)
 - [Use Cases](#use-cases)
-- [Schema](#schema)
 
 # Overview
 
@@ -69,6 +69,8 @@ CDS is designed to be a modular and flexible specification. Regulatory agencies 
 
 ![CDS APIs and Endpoints](https://i.imgur.com/wlSeEa0.png)
 
+## CDS OpenAPI Schema
+For CDS data and feed validation, please see the [OpenAPI schema description](https://github.com/openmobilityfoundation/cds-openapi). Interactive OpenAPI documentation for the CDS APIs, endpoints, fields, and data objects is also available on OMF's [Stoplight Interactive Documentation](https://openmobilityfnd.stoplight.io/docs/cds-openapi/83teyinnn1py6-curb-api) page.
 ## MDS Overlap
 
 Like the [Mobility Data Specification](https://github.com/openmobilityfoundation/mobility-data-specification/) (MDS), the CDS will be consumed by both cities and transportation providers operating in the public right of way. In many cases, the same mobility providers using curbs with CDS may also be interacting with other OMF [MDS Policy](https://github.com/openmobilityfoundation/mobility-data-specification/tree/main/policy), [MDS Provider](https://github.com/openmobilityfoundation/mobility-data-specification/tree/main/provider), and [MDS Agency](https://github.com/openmobilityfoundation/mobility-data-specification/tree/main/agency) data objects within the same [MDS Jurisdiction](https://github.com/openmobilityfoundation/mobility-data-specification/tree/main/jurisdiction) or [MDS Geography](https://github.com/openmobilityfoundation/mobility-data-specification/tree/main/geography), and using similar [MDS Metrics](https://github.com/openmobilityfoundation/mobility-data-specification/tree/main/metrics). Consistent with the Technology Design Principles codified in the [Technology Council's](https://github.com/openmobilityfoundation/governance/wiki/Technology-Council) OMF [Architectural Landscape Document](https://github.com/openmobilityfoundation/governance/blob/main/documents/OMF-MDS-Architectural-Landscape.pdf), the members of this working group are making reasonable best efforts to ensure that work is both _modular_ and _inter operable_ with other technology managed by the OMF as to avoid duplication and downstream implementation complexity. The first version of CDS intentionally has no direct connetions to MDS which allowed it to be created based strictly on real-world curb use cases and needs, but may align directly in future versions.
@@ -160,11 +162,6 @@ How cities use CDS depends on a variety of factors: their transportation goals, 
 
 A list of use cases is useful to show what's possible with CDS, to see many use cases up front for privacy considerations, and to use for policy discussions and policy language. More details and examples can be seen on the [CDS Use Cases](https://github.com/openmobilityfoundation/curb-data-specification/wiki/CDS-Use-Cases).
 
-[Top][toc]
-
-# Schema
-
-For details on the CDS schema in OpenAPI format and on Stoplight, please reference the [CDS OpenAPI](https://github.com/openmobilityfoundation/cds-openapi) repository.
 
 [Top][toc]
 

--- a/general-information.md
+++ b/general-information.md
@@ -18,7 +18,7 @@ This document contains specifications and common concepts that are shared betwee
 - [Range Boundaries](#range-boundaries)
 - [Responses](#responses)
 - [REST Endpoints](#rest-endpoints)
-- [Schema](#schema)
+- [OpenAPI Schema](#openapi-schema)
 - [Timestamp](#timestamp)
 - [Unit of Time Enum](#unit-of-time-enum)
 - [UUID](#uuid)
@@ -265,9 +265,10 @@ header but does not include this value; it MUST respond with a status of `406 No
 
 [Top][toc]
 
-# Schema
+# OpenAPI Schema
 
-There is no validation schema for the first release of CDS. A schema and/or digital definition will come in a future CDS release as the spec is refined after real-world usage and feedback. To leave your thoughts and follow along, see this [discussion issue](https://github.com/openmobilityfoundation/curb-data-specification/issues/87).
+
+For CDS data and feed validation, please see the [OpenAPI schema description](https://github.com/openmobilityfoundation/cds-openapi). Interactive OpenAPI documentation for the CDS APIs, endpoints, fields, and data objects is also available on OMF's [Stoplight Interactive Documentation](https://openmobilityfnd.stoplight.io/docs/cds-openapi/83teyinnn1py6-curb-api) page.
 
 [Top][toc]
 


### PR DESCRIPTION
Adds links to OpenAPI schema and Stoplight documentation to README.

---

## Explain pull request

This PR adds links to README for the OpenAPI CDS schema and to the Stoplight OpenAPI documentation.

## Is this a breaking change


* No, not breaking


## Impacted Spec

Which API(s) will this pull request impact?

README


