### PR TITLE
Curb zone name description

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ CDS is designed to be a modular and flexible specification. Regulatory agencies 
 
 ![CDS APIs and Endpoints](https://i.imgur.com/wlSeEa0.png)
 
-## CDS OpenAPI Schema
+## OpenAPI Schema
+
 For CDS data and feed validation, please see the [OpenAPI schema description](https://github.com/openmobilityfoundation/cds-openapi). Interactive OpenAPI documentation for the CDS APIs, endpoints, fields, and data objects is also available on OMF's [Stoplight Interactive Documentation](https://openmobilityfnd.stoplight.io/docs/cds-openapi/83teyinnn1py6-curb-api) page.
 
 ## MDS Overlap

--- a/curbs/README.md
+++ b/curbs/README.md
@@ -249,6 +249,7 @@ A Curb Zone is represented as a JSON object, whose fields are as follows:
 | `end_date` | [Timestamp][ts] | Optional | The time at which the data for this curb location ceases to be valid (_exclusive_, see [Range Boundaries](/general-information.md#range-boundaries)). If not present, the data will be presumed to be valid indefinitely. |
 | `location_references` | Array of [Location Reference](#location-reference) objects | Optional | One or more linear references for this Curb Zone. |
 | `name` | String | Optional | A human-readable name for this Curb Zone that identifies it to end users. |
+| `description` | String | Optional | A more detailed description of this Curb Zone, if needed. |
 | `user_zone_id` | String | Optional | An identifier that can be used to refer to this Curb Zone on physical signage as well as within mobile applications, typically for payment purposes. |
 | `street_name` | String | Optional | The name of the street that this Curb Zone is on, including directionals. SHOULD NOT contain address numbers. Examples: `Main Street NE` or `West Market St`. |
 | `cross_street_start_name` | String | Optional | The name of the cross street at or before the start of this Curb Zone (which cross street is at the start and end of the location is defined in the same direction as the linear reference for this curb; if no linear reference is provided, start and end SHOULD be oriented such that start comes before end when moving in the direction of travel for the roadway immediately adjacent to the curb.) |


### PR DESCRIPTION
---
name: Default
about: Suggest changes to CDS
title: Curb zone name description
---

# CDS Pull Request

In #148 there is a suggestion from @rneubauer to develop some standardized naming schemas for Zones to be used in the Curb Zones `name` field.

>  The idea would be that you could look at the name of the zone and understand the type of zone, and where it is located. 

The `name` field is an optional string defined as:
`A human-readable name for this Curb Zone that identifies it to end users.`
We could expand this definition to include a best practice recommendation for how zones should be named. On the other hand, 
since there are no constraints on what the `name` string contains, there's nothing in the specification that would stop a producer from implementing a particular naming schema based on their individual needs, so a change may not be necessary. In other words, you can use `name` in any way you want, so long as it's a string.  



## Explain pull request

This PR adds an optional `description` filed in addition to the `name` that would contain detailed description of the Curb Zone if needed. This is in line with what was done in Curb Objects.

I don't feel strongly about this. If we agree it's unnecessary or if it doesn't fulfill @rneubauer's needs,  I'm happy to withdraw or adjust the PR.

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which API(s) will this pull request impact?

* `Curbs`


## Additional context

Add any other context or screenshots about the feature request here.
