### PR TITLE
Add double parking event type

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ CDS is designed to be a modular and flexible specification. Regulatory agencies 
 
 ![CDS APIs and Endpoints](https://i.imgur.com/wlSeEa0.png)
 
-## CDS OpenAPI Schema
+## OpenAPI Schema
+
 For CDS data and feed validation, please see the [OpenAPI schema description](https://github.com/openmobilityfoundation/cds-openapi). Interactive OpenAPI documentation for the CDS APIs, endpoints, fields, and data objects is also available on OMF's [Stoplight Interactive Documentation](https://openmobilityfnd.stoplight.io/docs/cds-openapi/83teyinnn1py6-curb-api) page.
 
 ## MDS Overlap

--- a/events/README.md
+++ b/events/README.md
@@ -142,6 +142,7 @@ Curb Event Type `event_type` enumerates the set of possible types of Curb Event.
 | `scheduled_report` | event source reported status at a scheduled interval |
 | `enter_area`       | vehicle enters the relevant geographic area |
 | `exit_area`        | vehicle exits the relevant geographic area |
+| `double_parking`   | a vehicle stopped or parked in a travel lane |
 
 [Top][toc]
 


### PR DESCRIPTION

---
about: Suggest changes to CDS
title: Add double parking event type

---

# CDS Pull Request

In Issue #149, @rneubauer says:
>  the first thing that our customers asked for were double-parking events and locations


## Explain pull request
This adds a new `double_parking` value to the list of event types

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which API(s) will this pull request impact?

* `Events`



