### PR TITLE
Add Additional Providers for reporting events based on Provider ID.

### DIFF
--- a/data_source_operators.csv
+++ b/data_source_operators.csv
@@ -11,3 +11,11 @@ CurbIQ,d79d92ee-d554-4348-a749-bb5c24a60151,https://curbiq.io/
 Univrses,99cab7dc-4ae3-4f8b-82f9-99426910db03,https://univrses.com/
 Cleverciti,1e240e62-5871-497e-9e27-e8f798ce4829,https://www.cleverciti.com/
 Umojo,d0abb612-cc14-41ad-a3a8-a616e2c92ddb,https://www.umojo.com/
+ParkMobile,8d1917b4-ad33-4ef6-857f-87d4c6bef4f7,https://parkmobile.io/
+PayByPhone,fa9ef92a-979e-40c5-94e3-3efa86731dbc,https://www.paybyphone.com/
+Eleven-X,8570c84f-5172-40be-a30b-47cf4ac9fb75,https://eleven-x.com/
+TurboData,9472cfa8-bbcb-4ecb-b605-9b013d029f5d,https://www.turbodata.com/
+IPSGroup,97942825-be5f-434c-9b6c-9e40ad013266,https://www.ipsgroupinc.com
+T2 Systems,9018eea8-d115-423c-ab1c-0ef9cc97a0e3,https://www.t2systems.com
+RiseTek,c5934670-8648-4072-b8cb-1d6a95e3546b,https://risetekglobal.com/
+Gtechna,ce602dcb-f3ee-4fe9-a489-df0461e5bc86,https://www.gtechna.com/


### PR DESCRIPTION
For the purpose of providing data we are aggregating from various providers. I am asking for these providers to be added to the providers list:

Name UUID Website
ParkMobile 8d1917b4-ad33-4ef6-857f-87d4c6bef4f7 https://parkmobile.io/
PayByPhone fa9ef92a-979e-40c5-94e3-3efa86731dbc https://www.paybyphone.com/
Eleven-X 8570c84f-5172-40be-a30b-47cf4ac9fb75 https://eleven-x.com/
TurboData 9472cfa8-bbcb-4ecb-b605-9b013d029f5d https://www.turbodata.com/
IPS 97942825-be5f-434c-9b6c-9e40ad013266 https://www.ipsgroupinc.com/
T2 9018eea8-d115-423c-ab1c-0ef9cc97a0e3 https://www.t2systems.com/
RiseTek c5934670-8648-4072-b8cb-1d6a95e3546b https://risetekglobal.com/
Gtechna ce602dcb-f3ee-4fe9-a489-df0461e5bc86 https://www.gtechna.com/
