### PR TITLE
Add name and desciption fields to policy & rule

### DIFF
--- a/curbs/README.md
+++ b/curbs/README.md
@@ -465,6 +465,8 @@ A Policy is represented as a JSON object whose fields are as follows:
 | Name   | Type   | Required/Optional   | Description   |
 | ------ | ------ | ------------------- | ------------- |
 | `curb_policy_id` | UUID | Required | An ID that uniquely identifies this exact regulation across Curb Zones. Two Policy objects containing the same `curb_policy_id` MUST be completely identical. A `curb_policy_id` MUST NOT be reused -- once created, it must continue to refer to the identical policy forever. |
+| `name` | String | Optional | User friendly name of policy. |
+| `description` | String | Optional | Detailed description of policy. |
 | `published_date` | [Timestamp][ts] | Required | The date/time that this policy was first published in this data feed. |
 | `priority` | Integer | Required | Specifies which other policies this one takes precedence over. If two Policies on the same Curb Zone have overlapping [Time Spans](#time-span) and apply to the same user class, the one that applies at a given time is the one with the **lowest** priority. E.g., a priority of `1` takes precedence over a priority of `3`. Two Policies that apply to the same Curb Zone with overlapping Time Spans and equivalent User Class enumerations MUST NOT have the same priority. |
 | `rules` | Array of [Rules](#rule) | Required | The rule(s) that this policy applies. If a Policy specifies multiple rules, each rule MUST specify disjoint lists of user classes. |
@@ -481,6 +483,8 @@ It is a JSON object with the following fields:
 
 | Name   | Type   | Required/Optional   | Description   |
 | ------ | ------ | ------------------- | ------------- |
+| `name` | String | Optional | User friendly name of rule. |
+| `description` | String | Optional | Detailed description of rule. |
 | `activity` | [Activity](#activities) String | Required | The activity that is forbidden or permitted by this regulation. Value MUST be one of the [activities](#activities). |
 | `max_stay` | Integer | Optional | The length of time (in units of `max_stay_unit`) for which the curb may be used under this regulation. If not specified, the curb may be used under this regulation indefinitely. May not be applicable for all [activities](#activities). |
 | `max_stay_unit` | Enum | Optional | The [Unit of Time](/general-information.md#unit-of-time-enum) associated with the `max_stay` value. Defaults to "minute". |


### PR DESCRIPTION
## Explain pull request

At the moment there are no fields on the curb policy and policy rule schemas that allow humans looking at the data to easily tell things apart or ID policies. This adds `name` and `description` fields the Policy and Rule schemas so those can be filled in with info useful to human readers. This is similar to fields already present on MDS policies and rules. I've marked these new fields as optional so that this isn't a breaking change.

## Is this a breaking change

Not breaking as long as the new fields are optional.

* No, not breaking

## Impacted Spec

Which API(s) will this pull request impact?

* `Curbs`

## Additional context

I wonder if we may also need a field containing an arbitrary identifier from a user's system for doing round-trip matching of curb regulations, but at the moment I don't have a use case for that.
