### PR TITLE
Push Events Endpoint

### DIFF
--- a/events/README.md
+++ b/events/README.md
@@ -21,7 +21,7 @@ There are two different endpoints that are part of the Events API:
   - [Authorization](#authorization)
   * [Query Event](#query-event)
   * [Query Status](#query-status)
-  * [Post Event](#post-event)
+  * [Push Event](#push-event)
   * [Responses and Error Messages](#responses-and-error-messages)
 - [Data Objects](#data-objects)
   * [Curb Event](#curb-event)

--- a/events/README.md
+++ b/events/README.md
@@ -102,6 +102,8 @@ Authorization: required
 
 _Optional endpoint, as required by public agencies; if not implemented, the server should reply with `501 Not Implemented`._
 
+Servers implementing a `POST /events/event` API should be able to deduplicate events from a publisher based upon the `event_id` field. It should be expected that some events can be resent as a result of restoring connections between systems interrupted by network or system errors. 
+
 ### Responses
 
 _Possible HTTP Status Codes_: 

--- a/events/README.md
+++ b/events/README.md
@@ -78,7 +78,7 @@ Method: `GET`
 Authorization: recommended  
 `data` Payload: a JSON object with a `status` field containing an array of [Status](#status) objects.
 
-_Optional endpoint, as required by public agencies; if not implemented, the server should reply with `501 Not Implemented`._
+_Optional endpoint, as required by public agencies; if not implemented, the server should reply with `501 Not Implemented` if possible._
 
 ### Query Parameters
 

--- a/events/README.md
+++ b/events/README.md
@@ -21,6 +21,8 @@ There are two different endpoints that are part of the Events API:
   - [Authorization](#authorization)
   * [Query Event](#query-event)
   * [Query Status](#query-status)
+  * [Post Event](#post-event)
+  * [Responses and Error Messages](#responses-and-error-messages)
 - [Data Objects](#data-objects)
   * [Curb Event](#curb-event)
     * [Event Type](#event-type)
@@ -42,7 +44,7 @@ All endpoints return a JSON object containing the fields as specified in the [RE
 
 ## Authorization
 
-[Authorization](/general-information.md#authorization) is **required** for all of the Events endpoints, since depending on implementation, use cases, and fields required it may contain information only city transporation agencies should have access to.
+[Authorization](/general-information.md#authorization) is **recommended** for Events endpoints, since (depending on implementation, use cases, and fields required) it may contain information only city transporation agencies should have access to.
 
 [Top][toc]
 
@@ -50,6 +52,7 @@ All endpoints return a JSON object containing the fields as specified in the [RE
 
 Endpoint: `/events/events`  
 Method: `GET`  
+Authorization: recommended
 `data` Payload: a JSON object with the following fields:
   - `events`: an array of [Curb Event](#curb-event) objects. See [Event Times](/general-information.md#event-times) guidance about the order of data returned.
 
@@ -72,9 +75,10 @@ All query parameters are optional.
 
 Endpoint: `/events/status`  
 Method: `GET`  
+Authorization: recommended
 `data` Payload: a JSON object with a `status` field containing an array of [Status](#status) objects.
 
-_Optional endpoint; if not implemented, the server should reply with `501 Not Implemented`._
+_Optional endpoint, as required by public agencies; if not implemented, the server should reply with `501 Not Implemented`._
 
 ### Query Parameters
 
@@ -86,6 +90,51 @@ All query parameters are optional.
 | `curb_zone_id`  | [UUID][uuid] | The ID of a [Curb Zone](#curb-zone). If specified, only return sensor statuses within this zone. |
 | `curb_space_id` | [UUID][uuid] | The ID of a [Curb Space](#curb-space). If specified, only return sensor statuses within this space. |
 | `curb_object_id` | [UUID][uuid] | The ID of a [Curb Object](#curb-object). If specified, only return sensor statuses at this object. |
+
+[Top][toc]
+
+##  Push Event
+
+Endpoint: `/events/event`  
+Method: `POST`  
+Authorization: required
+`data` Payload: an array of [Curb Event](#curb-event) `events` objects.
+
+_Optional endpoint, as required by public agencies; if not implemented, the server should reply with `501 Not Implemented`._
+
+### Responses
+
+_Possible HTTP Status Codes_: 
+200,
+201,
+400,
+401,
+404,
+406,
+409,
+500,
+501
+
+See [Responses](#responses-and-error-messages) for details.
+
+### Event Errors:
+
+| `error`         | `error_description`              | `error_details`[]               |
+| -------         | -------------------              | -----------------               |
+| `bad_param`     | A validation error occurred      | Array of parameters with errors |
+| `missing_param` | A required parameter is missing  | Array of missing parameters     |
+
+[Top][toc]
+
+### Responses and Error Messages
+
+The response to a client request must include a valid HTTP status code defined in the [IANA HTTP Status Code Registry][iana].
+
+The response must set the `Content-Type` header as specified in the [Versioning section][versioning].
+
+Response bodies must be a `UTF-8` encoded JSON object.
+
+See the [Responses][responses], [Error Messages][error-messages], and [Bulk Responses][bulk-responses] sections, and the [schema][schema] for more details.
 
 [Top][toc]
 
@@ -291,7 +340,13 @@ For details on the CDS schema in OpenAPI format and on Stoplight, please referen
 
 [Top][toc]
 
-[toc]: #table-of-contents
-[uuid]: /general-information.md#uuid
-[ts]: /general-information.md#timestamp
+[bulk-responses]: /general-information.md#bulk-responses
+[error-messages]: /general-information.md#error-messages
+[iana]: https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
 [polygon]: /general-information.md#polygon
+[responses]: /general-information.md#responses
+[schema]: /general-information.md#schema/
+[toc]: #table-of-contents
+[ts]: /general-information.md#timestamp
+[uuid]: /general-information.md#uuid
+[versioning]: /general-information.md#versioning

--- a/events/README.md
+++ b/events/README.md
@@ -52,7 +52,7 @@ All endpoints return a JSON object containing the fields as specified in the [RE
 
 Endpoint: `/events/events`  
 Method: `GET`  
-Authorization: recommended
+Authorization: recommended  
 `data` Payload: a JSON object with the following fields:
   - `events`: an array of [Curb Event](#curb-event) objects. See [Event Times](/general-information.md#event-times) guidance about the order of data returned.
 
@@ -75,7 +75,7 @@ All query parameters are optional.
 
 Endpoint: `/events/status`  
 Method: `GET`  
-Authorization: recommended
+Authorization: recommended  
 `data` Payload: a JSON object with a `status` field containing an array of [Status](#status) objects.
 
 _Optional endpoint, as required by public agencies; if not implemented, the server should reply with `501 Not Implemented`._
@@ -97,7 +97,7 @@ All query parameters are optional.
 
 Endpoint: `/events/event`  
 Method: `POST`  
-Authorization: required
+Authorization: required  
 `data` Payload: an array of [Curb Event](#curb-event) `events` objects.
 
 _Optional endpoint, as required by public agencies; if not implemented, the server should reply with `501 Not Implemented`._

--- a/general-information.md
+++ b/general-information.md
@@ -276,6 +276,40 @@ List of acceptable endpoint responses.
 
 [Top][toc]
 
+### Bulk Responses
+
+For multi-record POST and PUT calls, e.g. sending Events using the post method, the bulk-response structure describes a list of failures is as follows:
+
+```jsonc
+{
+    "success": "...",
+    "total": "...",
+    "failures": [ {      // list of failure details
+        "item": { ... }, // copy of the item with the problem
+        "error": "...",
+        "error_description": "...",
+        "error_details": [ "...", "..." ]
+    }, {
+      // additional failure records
+    } ]
+}
+```
+
+| Field      | Type                                  | Field Description                                               |
+| ---------- | ------------------------------------- | --------------------------------------------------------------- |
+| `success`  | Integer                               | Number of successfully written records                          |
+| `total`    | Integer                               | Total number of provided records                                |
+| `failures` | [Failure Details](#failure-details)[] | Array of details about failed records (empty if all successful) |
+
+### Failure Details
+
+| Field               | Type                 | Field Description                                   |
+| ------------------- | -------------------- | --------------------------------------------------- |
+| `item`              | Event, etc.          | Invalid submitted item                              |
+| `error`             | Enum                 | Error code                                          |
+| `error_description` | String               | Human readable error description (can be localized) |
+| `error_details`     | String[]             | Array of fields with errors, if applicable          |
+
 # REST Endpoints
 
 All dynamic REST endpoints will return a JSON object containing the following fields:


### PR DESCRIPTION
## Explain pull request

Resolves #99 

A method to receive Event data defined in our events as a "push" where the source system that creates the event can initiate the integration and send the data to a receiving API endpoint. 

This is an optional endpoint, implemented at the discretion of the public agency.

Events can be pushed in batches or as single events.

Existing pull endpoints are still provided to support any preprocessing of data.

## Is this a breaking change

* No, not breaking

## Impacted Spec

Which API(s) will this pull request impact?

* `Events`


