### PR TITLE
Fix LineString GeoJSON example 

### DIFF
--- a/general-information.md
+++ b/general-information.md
@@ -166,11 +166,11 @@ A linestring is a GeoJSON geometry of type `"LineString"` (polyline) as defined 
 ```
 {
   "type": "LineString",
-  "coordinates": [[
+  "coordinates": [
     [-73.982105, 40.767932],
     [-73.973694, 40.764551],
     [-73.970913, 40.763627]
-  ]]
+  ]
 }
 ```
 


### PR DESCRIPTION
Fix LineString GeoJSON example

---
name: Default
about: Suggest changes to CDS
title: <Insert Title>

---

# CDS Pull Request


## Explain pull request

The LineString example in general-information.md was invalid GeoJSON because of an extra set of brackets []. 

## Is this a breaking change



* No, not breaking


## Impacted Spec

Which API(s) will this pull request impact?

* `Curbs`



